### PR TITLE
Finalizer thread breaks recycled Response

### DIFF
--- a/java/org/apache/catalina/connector/CoyoteOutputStream.java
+++ b/java/org/apache/catalina/connector/CoyoteOutputStream.java
@@ -20,6 +20,9 @@ import java.io.IOException;
 
 import javax.servlet.ServletOutputStream;
 
+import org.apache.juli.logging.Log;
+import org.apache.juli.logging.LogFactory;
+
 /**
  * Coyote implementation of the servlet output stream.
  *
@@ -29,6 +32,7 @@ import javax.servlet.ServletOutputStream;
 public class CoyoteOutputStream
     extends ServletOutputStream {
 
+    private static final Log log = LogFactory.getLog(CoyoteOutputStream.class);
 
     // ----------------------------------------------------- Instance Variables
 
@@ -98,16 +102,26 @@ public class CoyoteOutputStream
     @Override
     public void flush()
         throws IOException {
-        ob.flush();
+        if (isFinalizerThread()) {
+            log.warn("called by Finalizer thread.");
+        } else {
+            ob.flush();
+        }
     }
 
 
     @Override
     public void close()
         throws IOException {
-        ob.close();
+        if (isFinalizerThread()) {
+            log.warn("called by Finalizer thread.");
+        } else {
+            ob.close();
+        }
     }
 
-
+    private boolean isFinalizerThread() {
+        return "Finalizer".equals(Thread.currentThread().getName());
+    }
 }
 

--- a/java/org/apache/coyote/Response.java
+++ b/java/org/apache/coyote/Response.java
@@ -80,7 +80,7 @@ public final class Response {
     /**
      * Committed flag.
      */
-    boolean committed = false;
+    private volatile boolean committed = false;
 
 
     /**
@@ -207,12 +207,12 @@ public final class Response {
     }
 
 
-    public boolean isCommitted() {
+    public synchronized boolean isCommitted() {
         return committed;
     }
 
 
-    public void setCommitted(boolean v) {
+    public synchronized void setCommitted(boolean v) {
         if (v && !this.committed) {
             this.commitTime = System.currentTimeMillis();
         }
@@ -258,7 +258,7 @@ public final class Response {
 
     public void reset() throws IllegalStateException {
 
-        if (committed) {
+        if (isCommitted()) {
             throw new IllegalStateException();
         }
 
@@ -498,7 +498,7 @@ public final class Response {
 
     // --------------------
 
-    public void recycle() {
+    public synchronized void recycle() {
 
         contentType = null;
         contentLanguage = null;


### PR DESCRIPTION
When flush() or close() is called from Finalizer thread, it set committed flag of recycled Response instance.