### PR TITLE
Finalizer thread breaks recycled Response

### DIFF
--- a/java/org/apache/coyote/Response.java
+++ b/java/org/apache/coyote/Response.java
@@ -80,7 +80,7 @@ public final class Response {
     /**
      * Committed flag.
      */
-    private volatile boolean committed = false;
+    private boolean committed = false;
 
 
     /**


### PR DESCRIPTION
- When flush() or close() is called from Finalizer thread, it set committed flag of recycled Response instance.